### PR TITLE
Explicitly call tostring on error messages

### DIFF
--- a/src/testy.lua
+++ b/src/testy.lua
@@ -508,10 +508,10 @@ for _,t in ipairs( tests ) do
     n_errors = n_errors + 1
     if do_tap then
       fh:write( "# [ERROR] test function '", t.name, "' died:\n# ",
-                msg:gsub( "\n", "\n# " ), "\n" )
+                tostring(msg):gsub( "\n", "\n# " ), "\n" )
     else
       fh:write( "[ERROR] test function '", t.name, "' died:\n ",
-                msg:gsub( "\n", "\n " ), "\n" )
+                tostring(msg):gsub( "\n", "\n " ), "\n" )
     end
   else
     if not do_tap then


### PR DESCRIPTION
In case a user has created a custom exception object with its own __tostring method, we first need to call `tostring(msg)` before using `gsub`